### PR TITLE
Update webpack.config.js

### DIFF
--- a/src/bindings/js/wasm/webpack.config.js
+++ b/src/bindings/js/wasm/webpack.config.js
@@ -24,6 +24,7 @@ function getConfigs(mode = 'development') {
         'crypto': false,
         'fs': false,
         'path': false,
+        'perf_hooks': false,
       }
     },
     plugins: [


### PR DESCRIPTION
Ignore `perf_hooks` when installing wasm bindings.

While running `npm i` in the `src/bindings/js/wasm` folder I was getting the following error:
```
> openvinojs-wasm@1.0.0 postinstall
> npm run create_links && npm run build


> openvinojs-wasm@1.0.0 create_links
> mkdir -p bin && ln -sf ../../../../../bin/ia32/Release/openvino_wasm.js ./bin/ ln -sf ../../../../../bin/ia32/Release/openvino_wasm.wasm ./bin/


> openvinojs-wasm@1.0.0 build
> webpack

assets by status 19.4 MiB [compared for emit]
  assets by path ../types/lib/*.ts 3.14 KiB
    asset ../types/lib/types.d.ts 1.58 KiB [compared for emit]
    asset ../types/lib/helpers.d.ts 838 bytes [compared for emit]
    asset ../types/lib/wasm-model.d.ts 349 bytes [compared for emit]
    asset ../types/lib/maps.d.ts 194 bytes [compared for emit]
    asset ../types/lib/ov-wasm-module.d.ts 117 bytes [compared for emit]
    asset ../types/lib/index.d.ts 97 bytes [compared for emit]
  asset openvino_wasm.wasm 19.4 MiB [compared for emit] [from: bin/openvino_wasm.wasm] [copied]
  asset ../types/bin/openvino_wasm.d.ts 132 bytes [compared for emit]
assets by status 205 KiB [emitted]
  asset openvino-wasm.web.bundle.js 204 KiB [emitted] (name: openvino-wasm)
  asset _d87b.web.bundle.js 854 bytes [emitted]
runtime modules 7.83 KiB 10 modules
cacheable modules 183 KiB
  modules by path ../ 173 KiB
    ../common/dist/index.js 2.55 KiB [built] [code generated]
    ../common/dist/tensor.js 2.58 KiB [built] [code generated]
    + 4 modules
  modules by path ./lib/*.ts 10 KiB
    ./lib/index.ts 548 bytes [built] [code generated]
    ./lib/wasm-model.ts 4.74 KiB [built] [code generated]
    ./lib/ov-wasm-module.ts 521 bytes [built] [code generated]
    + 2 modules
  fs (ignored) 15 bytes [built] [code generated]
  fs (ignored) 15 bytes [built] [code generated]
  path (ignored) 15 bytes [built] [code generated]
  crypto (ignored) 15 bytes [optional] [built] [code generated]

ERROR in ../../../../bin/ia32/Release/openvino_wasm.js 8:106188-106221
Module not found: Error: Can't resolve 'perf_hooks' in '/home/msredema/projects/temp/openvino-wasm/bin/ia32/Release'
resolve 'perf_hooks' in '/home/msredema/projects/temp/openvino-wasm/bin/ia32/Release'
  Parsed request is a module
  No description file found in /home/msredema/projects/temp/openvino-wasm/bin/ia32/Release or above
  resolve as module
    /home/msredema/projects/temp/openvino-wasm/bin/ia32/Release/node_modules doesn't exist or is not a directory
    /home/msredema/projects/temp/openvino-wasm/bin/ia32/node_modules doesn't exist or is not a directory
    /home/msredema/projects/temp/openvino-wasm/bin/node_modules doesn't exist or is not a directory
    /home/msredema/projects/temp/openvino-wasm/node_modules doesn't exist or is not a directory
    /home/msredema/projects/temp/node_modules doesn't exist or is not a directory
    /home/msredema/projects/node_modules doesn't exist or is not a directory
    /home/msredema/node_modules doesn't exist or is not a directory
    /home/node_modules doesn't exist or is not a directory
    /node_modules doesn't exist or is not a directory
  aliased with mapping 'perf_hooks': 'empty' to 'empty'
    Parsed request is a module
    No description file found in /home/msredema/projects/temp/openvino-wasm/bin/ia32/Release or above
    resolve as module
      /home/msredema/projects/temp/openvino-wasm/bin/ia32/Release/node_modules doesn't exist or is not a directory
      /home/msredema/projects/temp/openvino-wasm/bin/ia32/node_modules doesn't exist or is not a directory
      /home/msredema/projects/temp/openvino-wasm/bin/node_modules doesn't exist or is not a directory
      /home/msredema/projects/temp/openvino-wasm/node_modules doesn't exist or is not a directory
      /home/msredema/projects/temp/node_modules doesn't exist or is not a directory
      /home/msredema/projects/node_modules doesn't exist or is not a directory
      /home/msredema/node_modules doesn't exist or is not a directory
      /home/node_modules doesn't exist or is not a directory
      /node_modules doesn't exist or is not a directory
 @ ./lib/ov-wasm-module.ts 6:40-71
 @ ./lib/wasm-model.ts 19:41-68
 @ ./lib/index.ts 6:37-60 7:21-44

webpack 5.79.0 compiled with 1 error in 3443 ms

assets by path ../types/ 3.27 KiB
  asset ../types/lib/types.d.ts 1.58 KiB [compared for emit]
  asset ../types/lib/helpers.d.ts 838 bytes [compared for emit]
  asset ../types/lib/wasm-model.d.ts 349 bytes [compared for emit]
  asset ../types/lib/maps.d.ts 194 bytes [compared for emit]
  asset ../types/bin/openvino_wasm.d.ts 132 bytes [compared for emit]
  asset ../types/lib/ov-wasm-module.d.ts 117 bytes [compared for emit]
  asset ../types/lib/index.d.ts 97 bytes [compared for emit]
asset openvino_wasm.wasm 19.4 MiB [compared for emit] [from: bin/openvino_wasm.wasm] [copied]
asset openvino-wasm.node.bundle.js 196 KiB [emitted] (name: openvino-wasm)
runtime modules 1.77 KiB 4 modules
cacheable modules 183 KiB
  modules by path ../ 173 KiB
    ../common/dist/index.js 2.55 KiB [built] [code generated]
    ../common/dist/tensor.js 2.58 KiB [built] [code generated]
    + 4 modules
  modules by path ./lib/*.ts 10 KiB
    ./lib/index.ts 548 bytes [built] [code generated]
    ./lib/wasm-model.ts 4.74 KiB [built] [code generated]
    ./lib/ov-wasm-module.ts 521 bytes [built] [code generated]
    + 2 modules
external "fs" 42 bytes [built] [code generated]
external "path" 42 bytes [built] [code generated]
external "crypto" 42 bytes [optional] [built] [code generated]
external "perf_hooks" 42 bytes [built] [code generated]
webpack 5.79.0 compiled successfully in 3427 ms
npm ERR! code 1
npm ERR! path /home/msredema/projects/temp/openvino-wasm/src/bindings/js/wasm
npm ERR! command failed
npm ERR! command sh -c npm run create_links && npm run build

npm ERR! A complete log of this run can be found in: /home/msredema/.npm/_logs/2023-06-21T09_28_24_811Z-debug-0.log
```

After a bit of debugging I found that changing the webpack solved this issue.