### PR TITLE
Minimal scopes of Input and Output classes functionality

### DIFF
--- a/src/bindings/js/node/binding.gyp
+++ b/src/bindings/js/node/binding.gyp
@@ -9,7 +9,7 @@
       "sources": [  
         "src/node_input.cpp",
         "src/node_output.cpp",
-        "src/shape_lite.cpp",
+        "src/shape.cpp",
         "src/async_reader.cpp",
         "src/pre_post_process_wrap.cpp",
         "src/errors.cpp",

--- a/src/bindings/js/node/include/helper.hpp
+++ b/src/bindings/js/node/include/helper.hpp
@@ -13,6 +13,7 @@
 #include <map>
 #include <openvino/core/type/element_type.hpp>
 #include <openvino/openvino.hpp>
+#include <unordered_set>
 #include <variant>
 
 #include "element_type.hpp"
@@ -50,6 +51,13 @@ template <>
 std::vector<size_t> js_to_cpp<std::vector<size_t>>(const Napi::CallbackInfo& info,
                                                    const size_t idx,
                                                    const std::vector<napi_types>& acceptable_types);
+
+/// @brief  A template specialization for TargetType std::unordered_set<std::string>
+template <>
+std::unordered_set<std::string> js_to_cpp<std::unordered_set<std::string>>(
+    const Napi::CallbackInfo& info,
+    const size_t idx,
+    const std::vector<napi_types>& acceptable_types);
 
 /// @brief  A template specialization for TargetType std::string
 template <>

--- a/src/bindings/js/node/include/model_wrap.hpp
+++ b/src/bindings/js/node/include/model_wrap.hpp
@@ -15,8 +15,8 @@
 #include <openvino/runtime/core.hpp>
 
 #include "compiled_model.hpp"
-#include "tensor.hpp"
 #include "errors.hpp"
+#include "tensor.hpp"
 
 class ModelWrap : public Napi::ObjectWrap<ModelWrap> {
 public:
@@ -54,6 +54,22 @@ public:
     Napi::Value get_name(const Napi::CallbackInfo& info);
     std::string get_name();
     std::shared_ptr<ov::Model> get_model();
+
+    /**
+     * @brief Helper function to access model outputs as an attribute of JavaScript Model.
+     * @param info Contains information about the environment and passed arguments
+     * Empty info array => Gets a single output of a model. If a model has more than one output, this method
+     * throws ov::Exception. info[0] of type string => Gets output of a model identified by tensor_name.
+     * info[0] of type int => Gets output of a model identified by index of output.
+     */
+    Napi::Value get_output(const Napi::CallbackInfo& info);
+
+    /**
+     * @brief Helper function to access model outputs
+     * @param info Contains information about the environment and passed arguments
+     * @return A Javascript Array containing Outputs
+     */
+    Napi::Value get_outputs(const Napi::CallbackInfo& info);
 
 private:
     std::shared_ptr<ov::Model> _model;

--- a/src/bindings/js/node/include/node_input.hpp
+++ b/src/bindings/js/node/include/node_input.hpp
@@ -4,7 +4,39 @@
 
 #include <openvino/core/node_input.hpp>
 
-class Input : public Napi::ObjectWrap<Input> {
+template <class NodeType>
+class Input : public Napi::ObjectWrap<Input<NodeType>> {};
+
+template<>
+class Input<ov::Node> : public Napi::ObjectWrap<Input<ov::Node>> {
+public:
+    Input(const Napi::CallbackInfo& info);
+
+    /**
+     * @brief Defines a Javascript Input class with constructor, static and instance properties and methods.
+     * @param env The environment in which to construct a JavaScript class.
+     * @return Napi::Function representing the constructor function for the Javascript Input class.
+     */
+    static Napi::Function GetClassConstructor(Napi::Env env);
+
+    /// @brief This method is called during initialization of OpenVino native add-on.
+    /// It exports JavaScript Input class.
+    static Napi::Object Init(Napi::Env env, Napi::Object exports);
+
+    void set_input(const std::shared_ptr<ov::Input<ov::Node>>& input);
+
+    static Napi::Object Wrap(Napi::Env env, std::shared_ptr<ov::Input<ov::Node>> input);
+
+    Napi::Value get_shape(const Napi::CallbackInfo& info);
+    
+    Napi::Value get_shape_data(const Napi::CallbackInfo& info);
+
+private:
+    std::shared_ptr<ov::Input<ov::Node>> _input;
+};
+
+template<>
+class Input<const ov::Node> : public Napi::ObjectWrap<Input<const ov::Node>> {
 public:
     Input(const Napi::CallbackInfo& info);
 
@@ -22,6 +54,10 @@ public:
     void set_input(const std::shared_ptr<ov::Input<const ov::Node>>& input);
 
     static Napi::Object Wrap(Napi::Env env, std::shared_ptr<ov::Input<const ov::Node>> input);
+
+    Napi::Value get_shape(const Napi::CallbackInfo& info);
+    
+    Napi::Value get_shape_data(const Napi::CallbackInfo& info);
 
 private:
     std::shared_ptr<ov::Input<const ov::Node>> _input;

--- a/src/bindings/js/node/include/node_output.hpp
+++ b/src/bindings/js/node/include/node_output.hpp
@@ -4,30 +4,56 @@
 
 #include <openvino/core/node_output.hpp>
 
-class Output : public Napi::ObjectWrap<Output> {
+template <class NodeType>
+class Output : public Napi::ObjectWrap<Output<NodeType>> {
 public:
     /**
      * @brief TO_DO
      */
-    Output(const Napi::CallbackInfo& info);
+    Output(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Output<NodeType>>(info) {}
 
     /**
      * @brief Defines a Javascript Output class with constructor, static and instance properties and methods.
      * @param env The environment in which to construct a JavaScript class.
      * @return Napi::Function representing the constructor function for the Javascript Output class.
      */
-    static Napi::Function GetClassConstructor(Napi::Env env);
+    static Napi::Function GetClassConstructor(Napi::Env env) {
+        return Output::DefineClass(env,
+                                   "Output",
+                                   {Output::InstanceMethod("getAnyName", &Output::get_any_name),
+                                    Output::InstanceMethod("toString", &Output::get_any_name)});
+    }
 
     /// @brief This method is called during initialization of OpenVino native add-on.
     /// It exports JavaScript Output class.
-    static Napi::Object Init(Napi::Env env, Napi::Object exports);
+    static Napi::Object Init(Napi::Env env, Napi::Object exports) {
+        auto func = GetClassConstructor(env);
 
-    ov::Output<const ov::Node> get_output() const;
+        Napi::FunctionReference* constructor = new Napi::FunctionReference();
+        *constructor = Napi::Persistent(func);
+        env.SetInstanceData(constructor);
 
-    static Napi::Object Wrap(Napi::Env env, ov::Output<const ov::Node> output);
+        exports.Set("Output", func);
+        return exports;
+    }
 
-    Napi::Value get_any_name(const Napi::CallbackInfo& info);
+    ov::Output<NodeType> get_output() const {
+        return _output;
+    }
+
+    static Napi::Object Wrap(Napi::Env env, ov::Output<NodeType> output) {
+        Napi::HandleScope scope(env);
+        Napi::Object obj = GetClassConstructor(env).New({});
+        Output* output_ptr = Napi::ObjectWrap<Output<NodeType>>::Unwrap(obj);
+        output_ptr->_output = output;
+        return obj;
+    }
+
+    Napi::Value get_any_name(const Napi::CallbackInfo& info) {
+        return Napi::String::New(info.Env(), _output.get_any_name());
+    }
 
 private:
-    ov::Output<const ov::Node> _output;
+    // ov::Output<const ov::Node> _output;
+    ov::Output<NodeType> _output;
 };

--- a/src/bindings/js/node/include/node_output.hpp
+++ b/src/bindings/js/node/include/node_output.hpp
@@ -4,56 +4,63 @@
 
 #include <openvino/core/node_output.hpp>
 
+#include "helper.hpp"
+
 template <class NodeType>
-class Output : public Napi::ObjectWrap<Output<NodeType>> {
+class Output : public Napi::ObjectWrap<Output<NodeType>> {};
+
+template <>
+class Output<ov::Node> : public Napi::ObjectWrap<Output<ov::Node>> {
 public:
-    /**
-     * @brief TO_DO
-     */
-    Output(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Output<NodeType>>(info) {}
+    Output(const Napi::CallbackInfo& info);
 
     /**
      * @brief Defines a Javascript Output class with constructor, static and instance properties and methods.
      * @param env The environment in which to construct a JavaScript class.
      * @return Napi::Function representing the constructor function for the Javascript Output class.
      */
-    static Napi::Function GetClassConstructor(Napi::Env env) {
-        return Output::DefineClass(env,
-                                   "Output",
-                                   {Output::InstanceMethod("getAnyName", &Output::get_any_name),
-                                    Output::InstanceMethod("toString", &Output::get_any_name)});
-    }
+    static Napi::Function GetClassConstructor(Napi::Env env);
 
     /// @brief This method is called during initialization of OpenVino native add-on.
     /// It exports JavaScript Output class.
-    static Napi::Object Init(Napi::Env env, Napi::Object exports) {
-        auto func = GetClassConstructor(env);
+    static Napi::Object Init(Napi::Env env, Napi::Object exports);
 
-        Napi::FunctionReference* constructor = new Napi::FunctionReference();
-        *constructor = Napi::Persistent(func);
-        env.SetInstanceData(constructor);
+    ov::Output<ov::Node> get_output() const;
 
-        exports.Set("Output", func);
-        return exports;
-    }
+    static Napi::Object Wrap(Napi::Env env, ov::Output<ov::Node> output);
 
-    ov::Output<NodeType> get_output() const {
-        return _output;
-    }
+    Napi::Value get_any_name(const Napi::CallbackInfo& info);
 
-    static Napi::Object Wrap(Napi::Env env, ov::Output<NodeType> output) {
-        Napi::HandleScope scope(env);
-        Napi::Object obj = GetClassConstructor(env).New({});
-        Output* output_ptr = Napi::ObjectWrap<Output<NodeType>>::Unwrap(obj);
-        output_ptr->_output = output;
-        return obj;
-    }
+    Napi::Value set_names(const Napi::CallbackInfo& info);
 
-    Napi::Value get_any_name(const Napi::CallbackInfo& info) {
-        return Napi::String::New(info.Env(), _output.get_any_name());
-    }
+    Napi::Value add_names(const Napi::CallbackInfo& info);
 
 private:
-    // ov::Output<const ov::Node> _output;
-    ov::Output<NodeType> _output;
+    ov::Output<ov::Node> _output;
+};
+
+template <>
+class Output<const ov::Node> : public Napi::ObjectWrap<Output<const ov::Node>> {
+public:
+    Output(const Napi::CallbackInfo& info);
+
+    /**
+     * @brief Defines a Javascript Output class with constructor, static and instance properties and methods.
+     * @param env The environment in which to construct a JavaScript class.
+     * @return Napi::Function representing the constructor function for the Javascript Output class.
+     */
+    static Napi::Function GetClassConstructor(Napi::Env env);
+
+    /// @brief This method is called during initialization of OpenVino native add-on.
+    /// It exports JavaScript Output class.
+    static Napi::Object Init(Napi::Env env, Napi::Object exports);
+
+    ov::Output<const ov::Node> get_output() const;
+
+    static Napi::Object Wrap(Napi::Env env, ov::Output<const ov::Node> output);
+
+    Napi::Value get_any_name(const Napi::CallbackInfo& info);
+
+private:
+    ov::Output<const ov::Node> _output;
 };

--- a/src/bindings/js/node/include/node_output.hpp
+++ b/src/bindings/js/node/include/node_output.hpp
@@ -29,6 +29,10 @@ public:
 
     static Napi::Object Wrap(Napi::Env env, ov::Output<ov::Node> output);
 
+    Napi::Value get_shape(const Napi::CallbackInfo& info);
+    
+    Napi::Value get_shape_data(const Napi::CallbackInfo& info);
+
     Napi::Value get_any_name(const Napi::CallbackInfo& info);
 
     Napi::Value set_names(const Napi::CallbackInfo& info);
@@ -58,6 +62,10 @@ public:
     ov::Output<const ov::Node> get_output() const;
 
     static Napi::Object Wrap(Napi::Env env, ov::Output<const ov::Node> output);
+
+    Napi::Value get_shape(const Napi::CallbackInfo& info);
+
+    Napi::Value get_shape_data(const Napi::CallbackInfo& info);
 
     Napi::Value get_any_name(const Napi::CallbackInfo& info);
 

--- a/src/bindings/js/node/include/shape.hpp
+++ b/src/bindings/js/node/include/shape.hpp
@@ -10,9 +10,9 @@
 #include "errors.hpp"
 #include "napi.h"
 
-class ShapeLite : public Napi::ObjectWrap<ShapeLite> {
+class Shape : public Napi::ObjectWrap<Shape> {
 public:
-    ShapeLite(const Napi::CallbackInfo& info);
+    Shape(const Napi::CallbackInfo& info);
 
     ov::Shape get_original();
 

--- a/src/bindings/js/node/include/tensor.hpp
+++ b/src/bindings/js/node/include/tensor.hpp
@@ -18,7 +18,7 @@
 #include "errors.hpp"
 #include "helper.hpp"
 #include "napi.h"
-#include "shape_lite.hpp"
+#include "shape.hpp"
 
 class TensorWrap : public Napi::ObjectWrap<TensorWrap> {
 public:
@@ -58,7 +58,7 @@ public:
      */
     Napi::Value get_data(const Napi::CallbackInfo& info);
 
-    /// @return A Javascript ShapeLite object containing a tensor shape.
+    /// @return A Javascript Shape object containing a tensor shape.
     Napi::Value get_shape(const Napi::CallbackInfo& info);
     /// @return Napi::String containing ov::element type.
     Napi::Value get_precision(const Napi::CallbackInfo& info);

--- a/src/bindings/js/node/src/addon.cpp
+++ b/src/bindings/js/node/src/addon.cpp
@@ -9,7 +9,7 @@
 #include "node_output.hpp"
 #include "openvino/openvino.hpp"
 #include "pre_post_process_wrap.hpp"
-#include "shape_lite.hpp"
+#include "shape.hpp"
 #include "tensor.hpp"
 
 Napi::String Method(const Napi::CallbackInfo& info) {
@@ -25,7 +25,7 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
     CompiledModelWrap::Init(env, exports);
     InferRequestWrap::Init(env, exports);
     TensorWrap::Init(env, exports);
-    ShapeLite::Init(env, exports);
+    Shape::Init(env, exports);
     PrePostProcessorWrap::Init(env, exports);
     Input::Init(env, exports);
     Output<const ov::Node>::Init(env, exports);

--- a/src/bindings/js/node/src/addon.cpp
+++ b/src/bindings/js/node/src/addon.cpp
@@ -28,7 +28,8 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
     ShapeLite::Init(env, exports);
     PrePostProcessorWrap::Init(env, exports);
     Input::Init(env, exports);
-    Output::Init(env, exports);
+    Output<const ov::Node>::Init(env, exports);
+    Output<ov::Node>::Init(env, exports);
     Napi::PropertyDescriptor element = Napi::PropertyDescriptor::Accessor<enumElementType>("element");
     exports.DefineProperty(element);
 

--- a/src/bindings/js/node/src/addon.cpp
+++ b/src/bindings/js/node/src/addon.cpp
@@ -27,7 +27,8 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
     TensorWrap::Init(env, exports);
     Shape::Init(env, exports);
     PrePostProcessorWrap::Init(env, exports);
-    Input::Init(env, exports);
+    Input<const ov::Node>::Init(env, exports);
+    Input<ov::Node>::Init(env, exports);
     Output<const ov::Node>::Init(env, exports);
     Output<ov::Node>::Init(env, exports);
     Napi::PropertyDescriptor element = Napi::PropertyDescriptor::Accessor<enumElementType>("element");

--- a/src/bindings/js/node/src/compiled_model.cpp
+++ b/src/bindings/js/node/src/compiled_model.cpp
@@ -43,7 +43,7 @@ Napi::Value CompiledModelWrap::create_infer_request(const Napi::CallbackInfo& in
 Napi::Value CompiledModelWrap::get_output(const Napi::CallbackInfo& info) {
     if (info.Length() == 0) {
         try {
-            return Output::Wrap(info.Env(), _compiled_model.output());
+            return Output<const ov::Node>::Wrap(info.Env(), _compiled_model.output());
         } catch (std::exception& e) {
             reportError(info.Env(), e.what());
             return Napi::Value();
@@ -53,10 +53,10 @@ Napi::Value CompiledModelWrap::get_output(const Napi::CallbackInfo& info) {
         return Napi::Value();
     } else if (info[0].IsString()) {
         auto tensor_name = info[0].ToString();
-        return Output::Wrap(info.Env(), _compiled_model.output(tensor_name));
+        return Output<const ov::Node>::Wrap(info.Env(), _compiled_model.output(tensor_name));
     } else if (info[0].IsNumber()) {
         auto idx = info[0].As<Napi::Number>().Int32Value();
-        return Output::Wrap(info.Env(), _compiled_model.output(idx));
+        return Output<const ov::Node>::Wrap(info.Env(), _compiled_model.output(idx));
     } else {
         reportError(info.Env(), "Error while getting compiled model outputs.");
         return Napi::Value();
@@ -69,7 +69,7 @@ Napi::Value CompiledModelWrap::get_outputs(const Napi::CallbackInfo& info) {
 
     size_t i = 0;
     for (auto& out : cm_outputs)
-        js_outputs[i++] = Output::Wrap(info.Env(), out);
+        js_outputs[i++] = Output<const ov::Node>::Wrap(info.Env(), out);
 
     return js_outputs;
 }
@@ -77,7 +77,7 @@ Napi::Value CompiledModelWrap::get_outputs(const Napi::CallbackInfo& info) {
 Napi::Value CompiledModelWrap::get_input(const Napi::CallbackInfo& info) {
     if (info.Length() == 0) {
         try {
-            return Output::Wrap(info.Env(), _compiled_model.input());
+            return Output<const ov::Node>::Wrap(info.Env(), _compiled_model.input());
         } catch (std::exception& e) {
             reportError(info.Env(), e.what());
             return Napi::Value();
@@ -87,10 +87,10 @@ Napi::Value CompiledModelWrap::get_input(const Napi::CallbackInfo& info) {
         return Napi::Value();
     } else if (info[0].IsString()) {
         auto tensor_name = info[0].ToString();
-        return Output::Wrap(info.Env(), _compiled_model.input(tensor_name));
+        return Output<const ov::Node>::Wrap(info.Env(), _compiled_model.input(tensor_name));
     } else if (info[0].IsNumber()) {
         auto idx = info[0].As<Napi::Number>().Int32Value();
-        return Output::Wrap(info.Env(), _compiled_model.input(idx));
+        return Output<const ov::Node>::Wrap(info.Env(), _compiled_model.input(idx));
     } else {
         reportError(info.Env(), "Error while getting compiled model inputs.");
         return Napi::Value();
@@ -103,7 +103,7 @@ Napi::Value CompiledModelWrap::get_inputs(const Napi::CallbackInfo& info) {
 
     size_t i = 0;
     for (auto& out : cm_inputs)
-        js_inputs[i++] = Output::Wrap(info.Env(), out);
+        js_inputs[i++] = Output<const ov::Node>::Wrap(info.Env(), out);
 
     return js_inputs;
 }

--- a/src/bindings/js/node/src/helper.cpp
+++ b/src/bindings/js/node/src/helper.cpp
@@ -84,6 +84,32 @@ std::vector<size_t> js_to_cpp<std::vector<size_t>>(const Napi::CallbackInfo& inf
 }
 
 template <>
+std::unordered_set<std::string> js_to_cpp<std::unordered_set<std::string>>(
+    const Napi::CallbackInfo& info,
+    const size_t idx,
+    const std::vector<napi_types>& acceptable_types) {
+    const auto elem = info[idx];
+    if (!elem.IsArray()) {
+        throw std::invalid_argument(std::string("Passed argument must be of type Array."));
+    } else {
+        auto array = elem.As<Napi::Array>();
+        size_t arrayLength = array.Length();
+
+        std::unordered_set<std::string> nativeArray;
+
+        for (size_t i = 0; i < arrayLength; i++) {
+            Napi::Value arrayItem = array[i];
+            if (!arrayItem.IsString()) {
+                throw std::invalid_argument(std::string("Passed array must contain only strings."));
+            }
+            Napi::String num = arrayItem.As<Napi::String>();
+            nativeArray.insert(num.Utf8Value());
+        }
+        return nativeArray;
+    }
+}
+
+template <>
 ov::element::Type_t js_to_cpp<ov::element::Type_t>(const Napi::CallbackInfo& info,
                                                    const size_t idx,
                                                    const std::vector<napi_types>& acceptable_types) {

--- a/src/bindings/js/node/src/infer_request.cpp
+++ b/src/bindings/js/node/src/infer_request.cpp
@@ -51,7 +51,7 @@ Napi::Value InferRequestWrap::infer(const Napi::CallbackInfo& info) {
 }
 
 Napi::Value InferRequestWrap::get_tensor(const Napi::CallbackInfo& info) {
-    auto* outputWrap = Napi::ObjectWrap<Output>::Unwrap(info[0].ToObject());
+    auto* outputWrap = Napi::ObjectWrap<Output<const ov::Node>>::Unwrap(info[0].ToObject());
     ov::Output<const ov::Node> output = outputWrap->get_output();
 
     ov::Tensor tensor = _infer_request.get_tensor(output);

--- a/src/bindings/js/node/src/node_input.cpp
+++ b/src/bindings/js/node/src/node_input.cpp
@@ -1,16 +1,16 @@
 #include "node_input.hpp"
+#include "shape.hpp"
 
-Input::Input(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Input>(info) {}
+Input<ov::Node>::Input(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Input<ov::Node>>(info) {}
 
-Napi::Function Input::GetClassConstructor(Napi::Env env) {
+Napi::Function Input<ov::Node>::GetClassConstructor(Napi::Env env) {
     return DefineClass(env,
                        "Input",
-                       {
-
-                       });
+                       {Input<ov::Node>::InstanceMethod("getShape", &Input<ov::Node>::get_shape),
+                        Input<ov::Node>::InstanceAccessor<&Input<ov::Node>::get_shape_data>("shape")});
 }
 
-Napi::Object Input::Init(Napi::Env env, Napi::Object exports) {
+Napi::Object Input<ov::Node>::Init(Napi::Env env, Napi::Object exports) {
     auto func = GetClassConstructor(env);
 
     Napi::FunctionReference* constructor = new Napi::FunctionReference();
@@ -21,14 +21,74 @@ Napi::Object Input::Init(Napi::Env env, Napi::Object exports) {
     return exports;
 }
 
-void Input::set_input(const std::shared_ptr<ov::Input<const ov::Node>>& input) {
+void Input<ov::Node>::set_input(const std::shared_ptr<ov::Input<ov::Node>>& input) {
     _input = input;
 }
 
-Napi::Object Input::Wrap(Napi::Env env, std::shared_ptr<ov::Input<const ov::Node>> input) {
+Napi::Object Input<ov::Node>::Wrap(Napi::Env env, std::shared_ptr<ov::Input<ov::Node>> input) {
     Napi::HandleScope scope(env);
     Napi::Object obj = GetClassConstructor(env).New({});
     Input* input_ptr = Napi::ObjectWrap<Input>::Unwrap(obj);
     input_ptr->set_input(input);
     return obj;
+}
+
+Napi::Value Input<ov::Node>::get_shape(const Napi::CallbackInfo& info) {
+    auto shape = _input->get_shape();
+    return Shape::Wrap(info.Env(), shape);
+}
+
+Napi::Value Input<ov::Node>::get_shape_data(const Napi::CallbackInfo& info) {
+    auto shape = _input->get_shape();
+    auto arr = Napi::Uint32Array::New(info.Env(), shape.size());
+    for (size_t i = 0; i < shape.size(); i++)
+        arr[i] = shape[i];
+
+    return arr;
+}
+
+Input<const ov::Node>::Input(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Input<const ov::Node>>(info) {}
+
+Napi::Function Input<const ov::Node>::GetClassConstructor(Napi::Env env) {
+    return DefineClass(env,
+                       "Input",
+                       {Input<const ov::Node>::InstanceMethod("getShape", &Input<const ov::Node>::get_shape),
+                        Input<const ov::Node>::InstanceAccessor<&Input<const ov::Node>::get_shape_data>("shape")});
+}
+
+Napi::Object Input<const ov::Node>::Init(Napi::Env env, Napi::Object exports) {
+    auto func = GetClassConstructor(env);
+
+    Napi::FunctionReference* constructor = new Napi::FunctionReference();
+    *constructor = Napi::Persistent(func);
+    env.SetInstanceData(constructor);
+
+    exports.Set("Input", func);
+    return exports;
+}
+
+void Input<const ov::Node>::set_input(const std::shared_ptr<ov::Input<const ov::Node>>& input) {
+    _input = input;
+}
+
+Napi::Object Input<const ov::Node>::Wrap(Napi::Env env, std::shared_ptr<ov::Input<const ov::Node>> input) {
+    Napi::HandleScope scope(env);
+    Napi::Object obj = GetClassConstructor(env).New({});
+    Input* input_ptr = Napi::ObjectWrap<Input>::Unwrap(obj);
+    input_ptr->set_input(input);
+    return obj;
+}
+
+Napi::Value Input<const ov::Node>::get_shape(const Napi::CallbackInfo& info) {
+    auto shape = _input->get_shape();
+    return Shape::Wrap(info.Env(), shape);
+}
+
+Napi::Value Input<const ov::Node>::get_shape_data(const Napi::CallbackInfo& info) {
+    auto shape = _input->get_shape();
+    auto arr = Napi::Uint32Array::New(info.Env(), shape.size());
+    for (size_t i = 0; i < shape.size(); i++)
+        arr[i] = shape[i];
+
+    return arr;
 }

--- a/src/bindings/js/node/src/node_output.cpp
+++ b/src/bindings/js/node/src/node_output.cpp
@@ -1,6 +1,6 @@
 #include "node_output.hpp"
 
-#include "shape_lite.hpp"
+#include "shape.hpp"
 
 Output<ov::Node>::Output(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Output<ov::Node>>(info) {}
 
@@ -40,7 +40,7 @@ Napi::Object Output<ov::Node>::Wrap(Napi::Env env, ov::Output<ov::Node> output) 
 
 Napi::Value Output<ov::Node>::get_shape(const Napi::CallbackInfo& info) {
     auto shape = _output.get_shape();
-    return ShapeLite::Wrap(info.Env(), shape);
+    return Shape::Wrap(info.Env(), shape);
 }
 
 Napi::Value Output<ov::Node>::get_shape_data(const Napi::CallbackInfo& info) {
@@ -105,7 +105,7 @@ Napi::Object Output<const ov::Node>::Wrap(Napi::Env env, ov::Output<const ov::No
 
 Napi::Value Output<const ov::Node>::get_shape(const Napi::CallbackInfo& info) {
     auto shape = _output.get_shape();
-    return ShapeLite::Wrap(info.Env(), shape);
+    return Shape::Wrap(info.Env(), shape);
 }
 
 Napi::Value Output<const ov::Node>::get_shape_data(const Napi::CallbackInfo& info) {

--- a/src/bindings/js/node/src/node_output.cpp
+++ b/src/bindings/js/node/src/node_output.cpp
@@ -1,37 +1,37 @@
-#include "node_output.hpp"
+// #include "node_output.hpp"
 
-Output::Output(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Output>(info) {}
+// Output::Output(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Output>(info) {}
 
-Napi::Function Output::GetClassConstructor(Napi::Env env) {
-    return DefineClass(
-        env,
-        "Output",
-        {InstanceMethod("getAnyName", &Output::get_any_name), InstanceMethod("toString", &Output::get_any_name)});
-}
+// Napi::Function Output::GetClassConstructor(Napi::Env env) {
+//     return DefineClass(
+//         env,
+//         "Output",
+//         {InstanceMethod("getAnyName", &Output::get_any_name), InstanceMethod("toString", &Output::get_any_name)});
+// }
 
-Napi::Object Output::Init(Napi::Env env, Napi::Object exports) {
-    auto func = GetClassConstructor(env);
+// Napi::Object Output::Init(Napi::Env env, Napi::Object exports) {
+//     auto func = GetClassConstructor(env);
 
-    Napi::FunctionReference* constructor = new Napi::FunctionReference();
-    *constructor = Napi::Persistent(func);
-    env.SetInstanceData(constructor);
+//     Napi::FunctionReference* constructor = new Napi::FunctionReference();
+//     *constructor = Napi::Persistent(func);
+//     env.SetInstanceData(constructor);
 
-    exports.Set("Output", func);
-    return exports;
-}
+//     exports.Set("Output", func);
+//     return exports;
+// }
 
-ov::Output<const ov::Node> Output::get_output() const {
-    return _output;
-}
+// ov::Output<const ov::Node> Output::get_output() const {
+//     return _output;
+// }
 
-Napi::Object Output::Wrap(Napi::Env env, ov::Output<const ov::Node> output) {
-    Napi::HandleScope scope(env);
-    Napi::Object obj = GetClassConstructor(env).New({});
-    Output* output_ptr = Napi::ObjectWrap<Output>::Unwrap(obj);
-    output_ptr->_output = output;
-    return obj;
-}
+// Napi::Object Output::Wrap(Napi::Env env, ov::Output<const ov::Node> output) {
+//     Napi::HandleScope scope(env);
+//     Napi::Object obj = GetClassConstructor(env).New({});
+//     Output* output_ptr = Napi::ObjectWrap<Output>::Unwrap(obj);
+//     output_ptr->_output = output;
+//     return obj;
+// }
 
-Napi::Value Output::get_any_name(const Napi::CallbackInfo& info) {
-    return Napi::String::New(info.Env(), _output.get_any_name());
-}
+// Napi::Value Output::get_any_name(const Napi::CallbackInfo& info) {
+//     return Napi::String::New(info.Env(), _output.get_any_name());
+// }

--- a/src/bindings/js/node/src/node_output.cpp
+++ b/src/bindings/js/node/src/node_output.cpp
@@ -1,11 +1,15 @@
 #include "node_output.hpp"
 
+#include "shape_lite.hpp"
+
 Output<ov::Node>::Output(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Output<ov::Node>>(info) {}
 
 Napi::Function Output<ov::Node>::GetClassConstructor(Napi::Env env) {
     return Output::DefineClass(env,
                                "Output",
-                               {Output<ov::Node>::InstanceMethod("getAnyName", &Output<ov::Node>::get_any_name),
+                               {Output<ov::Node>::InstanceMethod("getShape", &Output<ov::Node>::get_shape),
+                                Output<ov::Node>::InstanceAccessor<&Output<ov::Node>::get_shape_data>("shape"),
+                                Output<ov::Node>::InstanceMethod("getAnyName", &Output<ov::Node>::get_any_name),
                                 Output<ov::Node>::InstanceMethod("setNames", &Output<ov::Node>::set_names),
                                 Output<ov::Node>::InstanceMethod("addNames", &Output<ov::Node>::add_names),
                                 Output<ov::Node>::InstanceMethod("toString", &Output<ov::Node>::get_any_name)});
@@ -34,6 +38,20 @@ Napi::Object Output<ov::Node>::Wrap(Napi::Env env, ov::Output<ov::Node> output) 
     return obj;
 }
 
+Napi::Value Output<ov::Node>::get_shape(const Napi::CallbackInfo& info) {
+    auto shape = _output.get_shape();
+    return ShapeLite::Wrap(info.Env(), shape);
+}
+
+Napi::Value Output<ov::Node>::get_shape_data(const Napi::CallbackInfo& info) {
+    auto shape = _output.get_shape();
+    auto arr = Napi::Uint32Array::New(info.Env(), shape.size());
+    for (size_t i = 0; i < shape.size(); i++)
+        arr[i] = shape[i];
+
+    return arr;
+}
+
 Napi::Value Output<ov::Node>::get_any_name(const Napi::CallbackInfo& info) {
     return Napi::String::New(info.Env(), _output.get_any_name());
 }
@@ -56,7 +74,9 @@ Napi::Function Output<const ov::Node>::GetClassConstructor(Napi::Env env) {
     return Output::DefineClass(
         env,
         "Output",
-        {Output<const ov::Node>::InstanceMethod("getAnyName", &Output<const ov::Node>::get_any_name),
+        {Output<const ov::Node>::InstanceMethod("getShape", &Output<const ov::Node>::get_shape),
+         Output<const ov::Node>::InstanceAccessor<&Output<const ov::Node>::get_shape_data>("shape"),
+         Output<const ov::Node>::InstanceMethod("getAnyName", &Output<const ov::Node>::get_any_name),
          Output<const ov::Node>::InstanceMethod("toString", &Output<const ov::Node>::get_any_name)});
 }
 
@@ -81,6 +101,20 @@ Napi::Object Output<const ov::Node>::Wrap(Napi::Env env, ov::Output<const ov::No
     Output* output_ptr = Napi::ObjectWrap<Output>::Unwrap(obj);
     output_ptr->_output = output;
     return obj;
+}
+
+Napi::Value Output<const ov::Node>::get_shape(const Napi::CallbackInfo& info) {
+    auto shape = _output.get_shape();
+    return ShapeLite::Wrap(info.Env(), shape);
+}
+
+Napi::Value Output<const ov::Node>::get_shape_data(const Napi::CallbackInfo& info) {
+    auto shape = _output.get_shape();
+    auto arr = Napi::Uint32Array::New(info.Env(), shape.size());
+    for (size_t i = 0; i < shape.size(); i++)
+        arr[i] = shape[i];
+
+    return arr;
 }
 
 Napi::Value Output<const ov::Node>::get_any_name(const Napi::CallbackInfo& info) {

--- a/src/bindings/js/node/src/node_output.cpp
+++ b/src/bindings/js/node/src/node_output.cpp
@@ -1,37 +1,88 @@
-// #include "node_output.hpp"
+#include "node_output.hpp"
 
-// Output::Output(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Output>(info) {}
+Output<ov::Node>::Output(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Output<ov::Node>>(info) {}
 
-// Napi::Function Output::GetClassConstructor(Napi::Env env) {
-//     return DefineClass(
-//         env,
-//         "Output",
-//         {InstanceMethod("getAnyName", &Output::get_any_name), InstanceMethod("toString", &Output::get_any_name)});
-// }
+Napi::Function Output<ov::Node>::GetClassConstructor(Napi::Env env) {
+    return Output::DefineClass(env,
+                               "Output",
+                               {Output<ov::Node>::InstanceMethod("getAnyName", &Output<ov::Node>::get_any_name),
+                                Output<ov::Node>::InstanceMethod("setNames", &Output<ov::Node>::set_names),
+                                Output<ov::Node>::InstanceMethod("addNames", &Output<ov::Node>::add_names),
+                                Output<ov::Node>::InstanceMethod("toString", &Output<ov::Node>::get_any_name)});
+}
 
-// Napi::Object Output::Init(Napi::Env env, Napi::Object exports) {
-//     auto func = GetClassConstructor(env);
+Napi::Object Output<ov::Node>::Init(Napi::Env env, Napi::Object exports) {
+    auto func = GetClassConstructor(env);
 
-//     Napi::FunctionReference* constructor = new Napi::FunctionReference();
-//     *constructor = Napi::Persistent(func);
-//     env.SetInstanceData(constructor);
+    Napi::FunctionReference* constructor = new Napi::FunctionReference();
+    *constructor = Napi::Persistent(func);
+    env.SetInstanceData(constructor);
 
-//     exports.Set("Output", func);
-//     return exports;
-// }
+    exports.Set("Output", func);
+    return exports;
+}
 
-// ov::Output<const ov::Node> Output::get_output() const {
-//     return _output;
-// }
+ov::Output<ov::Node> Output<ov::Node>::get_output() const {
+    return _output;
+}
 
-// Napi::Object Output::Wrap(Napi::Env env, ov::Output<const ov::Node> output) {
-//     Napi::HandleScope scope(env);
-//     Napi::Object obj = GetClassConstructor(env).New({});
-//     Output* output_ptr = Napi::ObjectWrap<Output>::Unwrap(obj);
-//     output_ptr->_output = output;
-//     return obj;
-// }
+Napi::Object Output<ov::Node>::Wrap(Napi::Env env, ov::Output<ov::Node> output) {
+    Napi::HandleScope scope(env);
+    Napi::Object obj = GetClassConstructor(env).New({});
+    Output* output_ptr = Napi::ObjectWrap<Output>::Unwrap(obj);
+    output_ptr->_output = output;
+    return obj;
+}
 
-// Napi::Value Output::get_any_name(const Napi::CallbackInfo& info) {
-//     return Napi::String::New(info.Env(), _output.get_any_name());
-// }
+Napi::Value Output<ov::Node>::get_any_name(const Napi::CallbackInfo& info) {
+    return Napi::String::New(info.Env(), _output.get_any_name());
+}
+
+Napi::Value Output<ov::Node>::set_names(const Napi::CallbackInfo& info) {
+    auto names = js_to_cpp<std::unordered_set<std::string>>(info, 0, {js_array});
+    _output.set_names(names);
+    return Napi::Value();
+}
+
+Napi::Value Output<ov::Node>::add_names(const Napi::CallbackInfo& info) {
+    auto names = js_to_cpp<std::unordered_set<std::string>>(info, 0, {js_array});
+    _output.add_names(names);
+    return Napi::Value();
+}
+
+Output<const ov::Node>::Output(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Output<const ov::Node>>(info) {}
+
+Napi::Function Output<const ov::Node>::GetClassConstructor(Napi::Env env) {
+    return Output::DefineClass(
+        env,
+        "Output",
+        {Output<const ov::Node>::InstanceMethod("getAnyName", &Output<const ov::Node>::get_any_name),
+         Output<const ov::Node>::InstanceMethod("toString", &Output<const ov::Node>::get_any_name)});
+}
+
+Napi::Object Output<const ov::Node>::Init(Napi::Env env, Napi::Object exports) {
+    auto func = GetClassConstructor(env);
+
+    Napi::FunctionReference* constructor = new Napi::FunctionReference();
+    *constructor = Napi::Persistent(func);
+    env.SetInstanceData(constructor);
+
+    exports.Set("Output", func);
+    return exports;
+}
+
+ov::Output<const ov::Node> Output<const ov::Node>::get_output() const {
+    return _output;
+}
+
+Napi::Object Output<const ov::Node>::Wrap(Napi::Env env, ov::Output<const ov::Node> output) {
+    Napi::HandleScope scope(env);
+    Napi::Object obj = GetClassConstructor(env).New({});
+    Output* output_ptr = Napi::ObjectWrap<Output>::Unwrap(obj);
+    output_ptr->_output = output;
+    return obj;
+}
+
+Napi::Value Output<const ov::Node>::get_any_name(const Napi::CallbackInfo& info) {
+    return Napi::String::New(info.Env(), _output.get_any_name());
+}

--- a/src/bindings/js/node/src/shape.cpp
+++ b/src/bindings/js/node/src/shape.cpp
@@ -1,8 +1,8 @@
-#include "shape_lite.hpp"
+#include "shape.hpp"
 
-ShapeLite::ShapeLite(const Napi::CallbackInfo& info) : Napi::ObjectWrap<ShapeLite>(info) {
+Shape::Shape(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Shape>(info) {
     if (info.Length() != 2 && info.Length() != 0)  // default contructor takes 0 args
-        reportError(info.Env(), "Invalid number of arguments for ShapeLite constructor.");
+        reportError(info.Env(), "Invalid number of arguments for Shape constructor.");
     else if (info.Length() == 2) {
         auto dim = info[0].As<Napi::Number>().Int32Value();
         auto data_array = info[1].As<Napi::Uint32Array>();
@@ -11,16 +11,16 @@ ShapeLite::ShapeLite(const Napi::CallbackInfo& info) : Napi::ObjectWrap<ShapeLit
     }
 }
 
-Napi::Function ShapeLite::GetClassConstructor(Napi::Env env) {
+Napi::Function Shape::GetClassConstructor(Napi::Env env) {
     return DefineClass(env,
-                       "ShapeLite",
-                       {InstanceAccessor<&ShapeLite::get_data>("data"),
-                        InstanceMethod("getDim", &ShapeLite::get_dim),
-                        InstanceMethod("shapeSize", &ShapeLite::shape_size),
-                        InstanceMethod("getData", &ShapeLite::get_data)});
+                       "Shape",
+                       {InstanceAccessor<&Shape::get_data>("data"),
+                        InstanceMethod("getDim", &Shape::get_dim),
+                        InstanceMethod("shapeSize", &Shape::shape_size),
+                        InstanceMethod("getData", &Shape::get_data)});
 }
 
-Napi::Object ShapeLite::Init(Napi::Env env, Napi::Object exports) {
+Napi::Object Shape::Init(Napi::Env env, Napi::Object exports) {
     auto func = GetClassConstructor(env);
 
     Napi::FunctionReference* constructor = new Napi::FunctionReference();
@@ -31,15 +31,15 @@ Napi::Object ShapeLite::Init(Napi::Env env, Napi::Object exports) {
     return exports;
 }
 
-Napi::Object ShapeLite::Wrap(Napi::Env env, ov::Shape shape) {
+Napi::Object Shape::Wrap(Napi::Env env, ov::Shape shape) {
     Napi::HandleScope scope(env);
     auto obj = GetClassConstructor(env).New({});
-    auto t = Napi::ObjectWrap<ShapeLite>::Unwrap(obj);
+    auto t = Napi::ObjectWrap<Shape>::Unwrap(obj);
     t->set_shape(shape);
     return obj;
 }
 
-Napi::Value ShapeLite::get_data(const Napi::CallbackInfo& info) {
+Napi::Value Shape::get_data(const Napi::CallbackInfo& info) {
     auto arr = Napi::Uint32Array::New(info.Env(), _shape.size());
     for (size_t i = 0; i < _shape.size(); i++)
         arr[i] = _shape[i];
@@ -47,18 +47,18 @@ Napi::Value ShapeLite::get_data(const Napi::CallbackInfo& info) {
     return arr;
 }
 
-Napi::Value ShapeLite::get_dim(const Napi::CallbackInfo& info) {
+Napi::Value Shape::get_dim(const Napi::CallbackInfo& info) {
     return Napi::Number::New(info.Env(), this->_shape.size());
 }
 
-Napi::Value ShapeLite::shape_size(const Napi::CallbackInfo& info) {
+Napi::Value Shape::shape_size(const Napi::CallbackInfo& info) {
     return Napi::Number::New(info.Env(), ov::shape_size(this->_shape));
 }
 
-void ShapeLite::set_shape(const ov::Shape& shape) {
+void Shape::set_shape(const ov::Shape& shape) {
     _shape = shape;
 }
 
-ov::Shape ShapeLite::get_original() {
+ov::Shape Shape::get_original() {
     return this->_shape;
 }

--- a/src/bindings/js/node/src/tensor.cpp
+++ b/src/bindings/js/node/src/tensor.cpp
@@ -75,7 +75,7 @@ Napi::Value TensorWrap::get_data(const Napi::CallbackInfo& info) {
 
 Napi::Value TensorWrap::get_shape(const Napi::CallbackInfo& info){
     auto shape = _tensor.get_shape();
-    return ShapeLite::Wrap(info.Env(), shape);
+    return Shape::Wrap(info.Env(), shape);
 }
 
 Napi::Value TensorWrap::get_precision(const Napi::CallbackInfo& info){


### PR DESCRIPTION
### Details:
 - Implement Input and Output with template parameter _NodeType_ and template specializations of these classes for `ov::Node` and `const ov::Node`
 - Expose `Input.get_shape()` and `Output.get_shape()` methods
 - Expose `Input.shape` and `Output.shape` properties that contain shape dimensions
 - Rename ShapeLite class to Shape
 - Expose `Output<ov::Node>` `getAnyName`, `setNames` , `addNames` methods


### Tickets:
 - 113605
 - 113606
 - 114043
