### PR TITLE
Expose InferRequest.getOutputTensor() method

### DIFF
--- a/src/bindings/js/node/include/infer_request.hpp
+++ b/src/bindings/js/node/include/infer_request.hpp
@@ -60,6 +60,9 @@ public:
     /// @return A Javascript output tensor for the model. If model has several outputs, an error occurs.
     Napi::Value get_output_tensor(const Napi::CallbackInfo& info);
 
+    /// @return A Javascript object with model outputs.
+    Napi::Value get_output_tensors(const Napi::CallbackInfo& info);
+
 private:
     ov::InferRequest _infer_request;
 };

--- a/src/bindings/js/node/src/helper.cpp
+++ b/src/bindings/js/node/src/helper.cpp
@@ -102,8 +102,8 @@ std::unordered_set<std::string> js_to_cpp<std::unordered_set<std::string>>(
             if (!arrayItem.IsString()) {
                 throw std::invalid_argument(std::string("Passed array must contain only strings."));
             }
-            Napi::String num = arrayItem.As<Napi::String>();
-            nativeArray.insert(num.Utf8Value());
+            Napi::String str = arrayItem.As<Napi::String>();
+            nativeArray.insert(str.Utf8Value());
         }
         return nativeArray;
     }

--- a/src/bindings/js/node/src/helper.cpp
+++ b/src/bindings/js/node/src/helper.cpp
@@ -78,7 +78,7 @@ std::vector<size_t> js_to_cpp<std::vector<size_t>>(const Napi::CallbackInfo& inf
         else
             buf = elem.As<Napi::Int32Array>();
         auto data_ptr = static_cast<int*>(buf.ArrayBuffer().Data());
-        std::vector<size_t> vector(data_ptr, data_ptr + 4);
+        std::vector<size_t> vector(data_ptr, data_ptr + buf.ElementLength());
         return vector;
     }
 }

--- a/src/bindings/js/node/src/infer_request.cpp
+++ b/src/bindings/js/node/src/infer_request.cpp
@@ -56,7 +56,7 @@ Napi::Value InferRequestWrap::infer(const Napi::CallbackInfo& info) {
             auto array = elem.As<Napi::Array>();
             size_t i = 0;
 
-            //TO_DO
+            // TO_DO
             Napi::Value arrayItem = array[i];
             if (!arrayItem.IsObject()) {
                 throw std::invalid_argument(std::string("Passed array must contain objects."));
@@ -88,10 +88,8 @@ Napi::Value InferRequestWrap::infer(const Napi::CallbackInfo& info) {
                 ov::Tensor t = tensorWrap->get_tensor();
 
                 _infer_request.set_tensor(tensor_name, t);
-
             }
             _infer_request.infer();
-
         }
     } else {
         reportError(info.Env(), "Inference error.");
@@ -114,18 +112,11 @@ Napi::Value InferRequestWrap::get_output_tensor(const Napi::CallbackInfo& info) 
 
 Napi::Value InferRequestWrap::get_output_tensors(const Napi::CallbackInfo& info) {
     auto compiled_model = _infer_request.get_compiled_model().outputs();
-    Napi::HandleScope scope(info.Env());
     auto outputs_obj = Napi::Object::New(info.Env());
 
-    for (auto &node: compiled_model){
+    for (auto& node : compiled_model) {
         auto tensor = _infer_request.get_tensor(node);
-        auto wrapped_tensor = TensorWrap::Wrap(info.Env(), tensor);
-
-        Napi::ObjectReference* constructor = new Napi::ObjectReference();
-        *constructor = Napi::Persistent(wrapped_tensor);
-        info.Env().SetInstanceData(constructor);
-
-        outputs_obj.Set(node.get_any_name(), wrapped_tensor);
+        outputs_obj.Set(node.get_any_name(), TensorWrap::Wrap(info.Env(), tensor));
     }
 
     return outputs_obj;

--- a/src/bindings/js/node/src/infer_request.cpp
+++ b/src/bindings/js/node/src/infer_request.cpp
@@ -49,48 +49,20 @@ Napi::Value InferRequestWrap::set_input_tensor(const Napi::CallbackInfo& info) {
 Napi::Value InferRequestWrap::infer(const Napi::CallbackInfo& info) {
     if (info.Length() == 0)
         _infer_request.infer();
-    else if (info.Length() == 1) {
-        const auto elem = info[0];
+    else if (info.Length() == 1 && info[0].IsObject()) {
+        const auto inputs = info[0].As<Napi::Object>();
+        auto keys = inputs.GetPropertyNames();
 
-        if (elem.IsArray()) {
-            auto array = elem.As<Napi::Array>();
-            size_t i = 0;
+        for (size_t i = 0; i < keys.Length(); i++) {
+            auto tensor_name = static_cast<Napi::Value>(keys[i]).ToString().Utf8Value();
+            auto tensor_obj = inputs.Get(tensor_name).As<Napi::Object>();
 
-            // TO_DO
-            Napi::Value arrayItem = array[i];
-            if (!arrayItem.IsObject()) {
-                throw std::invalid_argument(std::string("Passed array must contain objects."));
-            }
-            Napi::Object obj = arrayItem.As<Napi::Object>();
+            auto* tensorWrap = Napi::ObjectWrap<TensorWrap>::Unwrap(tensor_obj);
+            auto tensor = tensorWrap->get_tensor();
 
-            auto* tensorWrap = Napi::ObjectWrap<TensorWrap>::Unwrap(obj);
-            ov::Tensor tensor = tensorWrap->get_tensor();
-
-            _infer_request.set_input_tensor(tensor);
-            _infer_request.infer();
-
-        } else if (elem.IsObject()) {
-            // elem z js = {"input:0": tensor}
-            Napi::Object obj = elem.As<Napi::Object>();
-
-            // for (const auto& it : obj) {
-            //     if(input.IsString()){
-            //         std::cout<< (it.first).As<String>().Utf8Value()<< " ";
-            //     }
-            // }
-
-            auto keys = obj.GetPropertyNames();
-            for (size_t i = 0; i < keys.Length(); i++) {
-                auto tensor_name = static_cast<Napi::Value>(keys[i]).ToString().Utf8Value();
-                auto tensor_obj = obj.Get(tensor_name).As<Napi::Object>();
-
-                auto* tensorWrap = Napi::ObjectWrap<TensorWrap>::Unwrap(tensor_obj);
-                ov::Tensor t = tensorWrap->get_tensor();
-
-                _infer_request.set_tensor(tensor_name, t);
-            }
-            _infer_request.infer();
+            _infer_request.set_tensor(tensor_name, tensor);
         }
+        _infer_request.infer();
     } else {
         reportError(info.Env(), "Inference error.");
     }

--- a/src/bindings/js/node/src/tensor.cpp
+++ b/src/bindings/js/node/src/tensor.cpp
@@ -59,7 +59,6 @@ void TensorWrap::set_tensor(const ov::Tensor& tensor) {
 }
 
 Napi::Object TensorWrap::Wrap(Napi::Env env, ov::Tensor tensor) {
-    Napi::HandleScope scope(env);
     auto obj = GetClassConstructor(env).New({});
     auto t = Napi::ObjectWrap<TensorWrap>::Unwrap(obj);
     t->set_tensor(tensor);
@@ -73,11 +72,11 @@ Napi::Value TensorWrap::get_data(const Napi::CallbackInfo& info) {
     return arr;
 }
 
-Napi::Value TensorWrap::get_shape(const Napi::CallbackInfo& info){
+Napi::Value TensorWrap::get_shape(const Napi::CallbackInfo& info) {
     auto shape = _tensor.get_shape();
     return Shape::Wrap(info.Env(), shape);
 }
 
-Napi::Value TensorWrap::get_precision(const Napi::CallbackInfo& info){
+Napi::Value TensorWrap::get_precision(const Napi::CallbackInfo& info) {
     return cpp_to_js<ov::element::Type_t, Napi::String>(info, _tensor.get_element_type());
 }

--- a/src/bindings/js/node/tests/basic.test.js
+++ b/src/bindings/js/node/tests/basic.test.js
@@ -1,96 +1,119 @@
 const ov = require('../build/Release/ov_node_addon.node');
 const path = require('path');
 
-function getModelPath(isFP16=false){
-    basePath = '../../python/tests/'
-    if (isFP16){
-        test_xml = path.join(basePath, 'test_utils', 'utils', 'test_model_fp16.xml')
-        test_bin = path.join(basePath, 'test_utils', 'utils', 'test_model_fp16.bin')
-    } else {
-        test_xml = path.join(basePath, 'test_utils', 'utils', 'test_model_fp32.xml')
-        test_bin = path.join(basePath, 'test_utils', 'utils', 'test_model_fp32.bin')
-    }
-    return (test_xml, test_bin)
+function getModelPath(isFP16=false) {
+  basePath = '../../python/tests/';
+  if (isFP16) {
+    test_xml = path.join(basePath, 'test_utils', 'utils', 'test_model_fp16.xml');
+    test_bin = path.join(basePath, 'test_utils', 'utils', 'test_model_fp16.bin');
+  } else {
+    test_xml = path.join(basePath, 'test_utils', 'utils', 'test_model_fp32.xml');
+    test_bin = path.join(basePath, 'test_utils', 'utils', 'test_model_fp32.bin');
+  }
+
+  return (test_xml, test_bin);
 }
-
-
 
 var test_xml, test_bin = getModelPath();
 
-
 describe('Output class', () => {
-    
-    const core = new ov.Core();
-    const model = core.read_model(test_xml);
-    const compiledModel = core.compile_model(model, 'CPU');
 
-    it.each([
-        [model],
-        [compiledModel]
-    ])('Mutual tests', (obj) => {
-        expect(obj.output() && typeof obj.output() === 'object').toBe(true);
-        expect(obj.outputs.length).toEqual(1);  
-        //test for a obj with one output
-        expect(obj.output().toString()).toEqual('fc_out');
-        expect(obj.output(0).toString()).toEqual('fc_out');
-        expect(obj.output('fc_out').toString()).toEqual('fc_out');
-        expect(obj.output(0).shape).toEqual([1, 10]);
-        expect(obj.output(0).getShape().getData()).toEqual([1, 10]);
-        expect(obj.output().getAnyName()).toEqual('fc_out');
-    });
+  const core = new ov.Core();
+  const model = core.read_model(test_xml);
+  const compiledModel = core.compile_model(model, 'CPU');
 
-    test('Ouput<ov::Node>.setNames() method', () => {
-        model.output().setNames(['bTestName', 'cTestName']);
-        expect(model.output().getAnyName()).toEqual('bTestName');
-    });
+  it.each([
+    [model],
+    [compiledModel],
+  ])('Mutual tests', (obj) => {
+    expect(obj.output() && typeof obj.output() === 'object').toBe(true);
+    expect(obj.outputs.length).toEqual(1);
+    //test for a obj with one output
+    expect(obj.output().toString()).toEqual('fc_out');
+    expect(obj.output(0).toString()).toEqual('fc_out');
+    expect(obj.output('fc_out').toString()).toEqual('fc_out');
+    expect(obj.output(0).shape).toEqual([1, 10]);
+    expect(obj.output(0).getShape().getData()).toEqual([1, 10]);
+    expect(obj.output().getAnyName()).toEqual('fc_out');
+  });
 
-    test('Ouput<ov::Node>.addNames() method', () => {
-        model.output().addNames(['aTestName']);
-        expect(model.output().getAnyName()).toEqual('aTestName');
-    });
+  test('Ouput<ov::Node>.setNames() method', () => {
+    model.output().setNames(['bTestName', 'cTestName']);
+    expect(model.output().getAnyName()).toEqual('bTestName');
+  });
 
-    test('Ouput<const ov::Node>.setNames() method', () => {
-        expect(() => compiledModel.output().setNames(['bTestName', 'cTestName'])).toThrow(TypeError);
-    });
+  test('Ouput<ov::Node>.addNames() method', () => {
+    model.output().addNames(['aTestName']);
+    expect(model.output().getAnyName()).toEqual('aTestName');
+  });
 
-    test('Ouput<const ov::Node>.addNames() method', () => {
-        expect(() => compiledModel.output().addNames(['aTestName'])).toThrow(TypeError);
-    });
+  test('Ouput<const ov::Node>.setNames() method', () => {
+    expect(() => compiledModel.output().setNames(['bTestName', 'cTestName'])).toThrow(TypeError);
+  });
+
+  test('Ouput<const ov::Node>.addNames() method', () => {
+    expect(() => compiledModel.output().addNames(['aTestName'])).toThrow(TypeError);
+  });
 
 });
 
 describe('Input class for ov::Input<const ov::Node>', () => {
-    const core = new ov.Core();
-    const model = core.read_model(test_xml);
-    const compiledModel = core.compile_model(model, 'CPU');
+  const core = new ov.Core();
+  const model = core.read_model(test_xml);
+  const compiledModel = core.compile_model(model, 'CPU');
 
-    test('CompiledModel.input() method', () => {
-        // TO_DO check if object is an instance of a value/class
-        expect(compiledModel.input() && typeof compiledModel.input() === 'object').toBe(true)
-    });
+  test('CompiledModel.input() method', () => {
+    // TO_DO check if object is an instance of a value/class
+    expect(compiledModel.input() && typeof compiledModel.input() === 'object').toBe(true);
+  });
 
-    test('CompiledModel.inputs property', () => {
-        expect(compiledModel.inputs.length).toEqual(1);     
-    });
+  test('CompiledModel.inputs property', () => {
+    expect(compiledModel.inputs.length).toEqual(1);
+  });
 
-    test('CompiledModel.input().ToString() method', () => {
-        //test for a model with one output
-        expect(compiledModel.input().toString()).toEqual('data');
-    });
+  test('CompiledModel.input().ToString() method', () => {
+    //test for a model with one output
+    expect(compiledModel.input().toString()).toEqual('data');
+  });
 
-    test('CompiledModel.input(idx: number).ToString() method', () => {
-        expect(compiledModel.input(0).toString()).toEqual('data');
-    });
+  test('CompiledModel.input(idx: number).ToString() method', () => {
+    expect(compiledModel.input(0).toString()).toEqual('data');
+  });
 
-    test('CompiledModel.input(tensorName: string).ToString() method', () => {
-        expect(compiledModel.input('data').toString()).toEqual('data');
-    });
+  test('CompiledModel.input(tensorName: string).ToString() method', () => {
+    expect(compiledModel.input('data').toString()).toEqual('data');
+  });
 
-    test('Input.shape property with dimensions', () => {
-        expect(compiledModel.input(0).shape).toEqual([1, 3, 32, 32]);
-    });
+  test('Input.shape property with dimensions', () => {
+    expect(compiledModel.input(0).shape).toEqual([1, 3, 32, 32]);
+  });
 
-    test('Input.getShape() method', () => {
-        expect(compiledModel.input(0).getShape().getData()).toEqual([1, 3, 32, 32]);
-    });
+  test('Input.getShape() method', () => {
+    expect(compiledModel.input(0).getShape().getData()).toEqual([1, 3, 32, 32]);
+  });
+});
+
+describe('InferRequest', () => {
+  const core = new ov.Core();
+  const model = core.read_model(test_xml);
+  const compiledModel = core.compile_model(model, 'CPU');
+  const inferRequest = compiledModel.create_infer_request();
+
+  const tensor = new ov.Tensor(
+    ov.element.f32,
+    Int32Array.from([1, 3, 32, 32]),
+    Float32Array.from({length: 3072}, () => Math.random() )
+  );
+
+  inferRequest.infer({'data': tensor});
+  result = inferRequest.getOutputTensors();
+
+  test('getOuputTensors() method', () => {
+    expect(Object.keys(result)).toEqual(['fc_out']);
+  });
+
+  test('getOuputTensors() method', () => {
+    expect(result['fc_out'].data.length).toEqual(10);
+  });
+
 });


### PR DESCRIPTION
### Details:
 - Expose `InferRequest.getOutputTensors()` method that return a JS objects with output tensors
 - Expand `infer()` method to accept `{'input:0': tensor}` object as a parameter

### Tickets:
 - 115204
