### PR TITLE
Fix method name get_type_name() -> to_string()

### DIFF
--- a/src/bindings/js/node/src/helper.cpp
+++ b/src/bindings/js/node/src/helper.cpp
@@ -162,7 +162,7 @@ ov::Shape js_to_cpp<ov::Shape>(const Napi::CallbackInfo& info,
 template <>
 Napi::String cpp_to_js<ov::element::Type_t, Napi::String>(const Napi::CallbackInfo& info,
                                                           const ov::element::Type_t type) {
-    return Napi::String::New(info.Env(), ov::element::Type(type).get_type_name());
+    return Napi::String::New(info.Env(), ov::element::Type(type).to_string());
 }
 
 ov::Tensor get_request_tensor(ov::InferRequest infer_request, std::string key) {


### PR DESCRIPTION
Rename get_type_name() -> to_string()