### PR TITLE
Add Model.input()

### DIFF
--- a/src/bindings/js/node/include/model_wrap.hpp
+++ b/src/bindings/js/node/include/model_wrap.hpp
@@ -46,11 +46,28 @@ public:
     std::shared_ptr<ov::Model> get_model();
 
     /**
-     * @brief Helper function to access model outputs as an attribute of JavaScript Model.
-     * @param info Contains information about the environment and passed arguments
-     * Empty info array => Gets a single output of a model. If a model has more than one output, this method
-     * throws ov::Exception. info[0] of type string => Gets output of a model identified by tensor_name.
-     * info[0] of type int => Gets output of a model identified by index of output.
+     * @brief Helper function to access model inputs.
+     * @param info contains passed arguments.
+     * Empty info array:
+     * @param info Gets a single input of a model. If a model has more than one input, this method
+     * throws ov::Exception. 
+     * One param of type string:
+     * @param info[0] Gets input of a model identified by tensor_name.
+     * One param of type int:
+     * @param info[0] Gets input of a model identified by index of input.
+     */
+    Napi::Value get_input(const Napi::CallbackInfo& info);
+
+    /**
+     * @brief Helper function to access model outputs.
+     * @param info contains passed arguments.
+     * Empty info array:
+     * @param info Gets a single output of a model. If a model has more than one output, this method
+     * throws ov::Exception. 
+     * One param of type string:
+     * @param info[0] Gets output of a model identified by tensor_name.
+     * One param of type int:
+     * @param info[0] Gets output of a model identified by index of output.
      */
     Napi::Value get_output(const Napi::CallbackInfo& info);
 

--- a/src/bindings/js/node/lib/addon.ts
+++ b/src/bindings/js/node/lib/addon.ts
@@ -24,6 +24,7 @@ interface Model {
   outputs: Output[];
   inputs: Output[];
   output(nameOrId?: string | number): Output;
+  input(nameOrId?: string | number): Output;
   getName(): string;
 }
 

--- a/src/bindings/js/node/tests/basic.test.js
+++ b/src/bindings/js/node/tests/basic.test.js
@@ -11,10 +11,10 @@ let testXml = getModelPath();
 const core = new ov.Core();
 const model = core.readModelSync(testXml);
 const compiledModel = core.compileModel(model, 'CPU');
+const modelLike = [[model],
+  [compiledModel]];
 
 describe('Output class', () => {
-  const modelLike = [[model],
-    [compiledModel]];
 
   modelLike.forEach( ([obj]) => {
     it('Output getters and properties', () => {
@@ -58,30 +58,36 @@ describe('Output class', () => {
 });
 
 describe('Input class for ov::Input<const ov::Node>', () => {
-  it('CompiledModel.input() method', () => {
-    // TO_DO check if object is an instance of a value/class
-    assert.strictEqual(typeof compiledModel.input(), 'object');
-  });
+  modelLike.forEach( ([obj]) => {
+    it('input() is typeof object', () => {
+      assert.strictEqual(typeof obj.input(), 'object');
+    });
 
-  it('CompiledModel.inputs property', () => {
-    assert.equal(compiledModel.inputs.length, 1);
-  });
+    it('inputs property', () => {
+      assert.strictEqual(obj.inputs.length, 1);
+    });
 
-  it('CompiledModel.input().ToString() method', () => {
-    //test for a model with one output
-    assert.strictEqual(compiledModel.input().toString(), 'data');
-  });
+    it('input().toString()', () => {
+      assert.strictEqual(obj.input().toString(), 'data');
+    });
 
-  it('CompiledModel.input(idx: number).ToString() method', () => {
-    assert.strictEqual(compiledModel.input(0).toString(), 'data');
-  });
+    it('input(idx: number).ToString() method', () => {
+      assert.strictEqual(obj.input(0).toString(), 'data');
+    });
 
-  it('CompiledModel.input(tensorName: string).ToString() method', () => {
-    assert.strictEqual(compiledModel.input('data').toString(), 'data');
-  });
+    it('input(tensorName: string).ToString() method', () => {
+      assert.strictEqual(obj.input('data').toString(), 'data');
+    });
 
-  it('Input.shape property with dimensions', () => {
-    assert.deepStrictEqual(compiledModel.input(0).shape, [1, 3, 32, 32]);
+    it('input().getAnyName() and anyName', () => {
+      assert.strictEqual(obj.input().getAnyName(), 'data');
+      assert.strictEqual(obj.input().anyName, 'data');
+    });
+
+    it('input(idx).shape property with dimensions', () => {
+      assert.deepStrictEqual(obj.input(0).shape, [1, 3, 32, 32]);
+      assert.deepStrictEqual(obj.input(0).getShape(), [1, 3, 32, 32]);
+    });
   });
 
 });


### PR DESCRIPTION
### Details:
 - Expose `Model.input()`, `Model.input(size_t i)` and `Model.input(const std::string& tensor_name)` as  `Model.input(nameOrId?: string | number)`;

### Tickets:
 - *[122107]*
