### PR TITLE
Rename getPrecision() to getElementType()

### DIFF
--- a/src/bindings/js/node/include/tensor.hpp
+++ b/src/bindings/js/node/include/tensor.hpp
@@ -61,7 +61,7 @@ public:
     /** @return Napi::Array containing a tensor shape. */
     Napi::Value get_shape(const Napi::CallbackInfo& info);
     /** @return Napi::String containing ov::element type. */
-    Napi::Value get_precision(const Napi::CallbackInfo& info);
+    Napi::Value get_element_type(const Napi::CallbackInfo& info);
 
 private:
     ov::Tensor _tensor;

--- a/src/bindings/js/node/lib/addon.ts
+++ b/src/bindings/js/node/lib/addon.ts
@@ -62,7 +62,7 @@ interface CompiledModel {
 
 interface Tensor {
   data: number[];
-  getPrecision(): element;
+  getElementType(): element;
   getShape(): number[];
   getData(): number[];
 }

--- a/src/bindings/js/node/src/tensor.cpp
+++ b/src/bindings/js/node/src/tensor.cpp
@@ -44,7 +44,7 @@ Napi::Function TensorWrap::GetClassConstructor(Napi::Env env) {
                        {InstanceAccessor<&TensorWrap::get_data>("data"),
                         InstanceMethod("getData", &TensorWrap::get_data),
                         InstanceMethod("getShape", &TensorWrap::get_shape),
-                        InstanceMethod("getPrecision", &TensorWrap::get_precision)});
+                        InstanceMethod("getElementType", &TensorWrap::get_element_type)});
 }
 
 Napi::Object TensorWrap::Init(Napi::Env env, Napi::Object exports) {
@@ -138,6 +138,6 @@ Napi::Value TensorWrap::get_shape(const Napi::CallbackInfo& info) {
     return cpp_to_js<ov::Shape, Napi::Array>(info, _tensor.get_shape());
 }
 
-Napi::Value TensorWrap::get_precision(const Napi::CallbackInfo& info) {
+Napi::Value TensorWrap::get_element_type(const Napi::CallbackInfo& info) {
     return cpp_to_js<ov::element::Type_t, Napi::String>(info, _tensor.get_element_type());
 }

--- a/src/bindings/js/node/tests/tensor.test.js
+++ b/src/bindings/js/node/tests/tensor.test.js
@@ -38,7 +38,7 @@ describe('Tensor without data parameters', () => {
 describe('Tensor data', () => {
 
   params.forEach(([type, stringType, data]) => {
-    it(`Set tensor data with ${stringType} precision`, () => {
+    it(`Set tensor data with ${stringType} element type`, () => {
       const tensor = new ov.Tensor(type, shape, data);
       assert.deepStrictEqual(tensor.data, data);
     });
@@ -133,7 +133,7 @@ describe('Tensor element type', () => {
   params.forEach(([elemType, , data]) => {
     it(`Comparison of ov.element ${elemType} got from Tensor object`, () => {
       const tensor = new ov.Tensor(elemType, shape, data);
-      assert.strictEqual(tensor.getPrecision(), elemType);
+      assert.strictEqual(tensor.getElementType(), elemType);
     });
   });
 });


### PR DESCRIPTION
### Details:
 - Allign the name of `Tensor` class method get_element_type() to Python and C++ APIs 