### PR TITLE
Move SetInstanceData to addon.cpp

### DIFF
--- a/src/bindings/js/node/include/addon.hpp
+++ b/src/bindings/js/node/include/addon.hpp
@@ -1,0 +1,12 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <napi.h>
+
+struct AddonData {
+    AddonData() {};
+    Napi::FunctionReference* core_prototype;
+    Napi::FunctionReference* model_prototype;
+};

--- a/src/bindings/js/node/include/addon.hpp
+++ b/src/bindings/js/node/include/addon.hpp
@@ -6,7 +6,6 @@
 #include <napi.h>
 
 struct AddonData {
-    AddonData() {};
     Napi::FunctionReference* core_prototype;
     Napi::FunctionReference* model_prototype;
 };

--- a/src/bindings/js/node/src/addon.cpp
+++ b/src/bindings/js/node/src/addon.cpp
@@ -1,6 +1,8 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#include "addon.hpp"
+
 #include <napi.h>
 
 #include "compiled_model.hpp"
@@ -10,12 +12,15 @@
 #include "model_wrap.hpp"
 #include "node_output.hpp"
 #include "openvino/openvino.hpp"
-#include "tensor.hpp"
 #include "partial_shape_wrap.hpp"
 #include "preprocess/preprocess.hpp"
+#include "tensor.hpp"
 
 /** @brief Initialize native add-on */
 Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
+    auto data = new AddonData();
+    env.SetInstanceData<AddonData>(data);
+
     ModelWrap::Init(env, exports);
     CoreWrap::Init(env, exports);
     CompiledModelWrap::Init(env, exports);

--- a/src/bindings/js/node/src/compiled_model.cpp
+++ b/src/bindings/js/node/src/compiled_model.cpp
@@ -22,9 +22,6 @@ Napi::Function CompiledModelWrap::GetClassConstructor(Napi::Env env) {
 Napi::Object CompiledModelWrap::Init(Napi::Env env, Napi::Object exports) {
     auto func = GetClassConstructor(env);
 
-    Napi::FunctionReference* constructor = new Napi::FunctionReference();
-    *constructor = Napi::Persistent(func);
-    env.SetInstanceData(constructor);
 
     exports.Set("CompiledModel", func);
     return exports;

--- a/src/bindings/js/node/src/core_wrap.cpp
+++ b/src/bindings/js/node/src/core_wrap.cpp
@@ -24,14 +24,14 @@ Napi::Function CoreWrap::GetClassConstructor(Napi::Env env) {
 }
 
 Napi::Object CoreWrap::Init(Napi::Env env, Napi::Object exports) {
-    auto func = GetClassConstructor(env);
+    const auto& prototype = GetClassConstructor(env);
 
-    Napi::FunctionReference* constructor = new Napi::FunctionReference();
-    *constructor = Napi::Persistent(func);
-    auto data = env.GetInstanceData<AddonData>();
-    data->core_prototype = constructor;
+    const auto ref = new Napi::FunctionReference();
+    *ref = Napi::Persistent(prototype);
+    const auto data = env.GetInstanceData<AddonData>();
+    data->core_prototype = ref;
 
-    exports.Set("Core", func);
+    exports.Set("Core", prototype);
     return exports;
 }
 

--- a/src/bindings/js/node/src/core_wrap.cpp
+++ b/src/bindings/js/node/src/core_wrap.cpp
@@ -75,12 +75,13 @@ Napi::Value CoreWrap::read_model_async(const Napi::CallbackInfo& info) {
 Napi::Value CoreWrap::compile_model_sync(const Napi::CallbackInfo& info,
                                          const Napi::Object& model,
                                          const Napi::String& device) {
-    if (model.InstanceOf(info.Env().GetInstanceData<AddonData>()->model_prototype->Value().As<Napi::Function>())) {
+    const auto model_prototype = info.Env().GetInstanceData<AddonData>()->model_prototype;
+    if (model_prototype && model.InstanceOf(model_prototype->Value().As<Napi::Function>())) {
         const auto m = Napi::ObjectWrap<ModelWrap>::Unwrap(model);
         const auto& compiled_model = _core.compile_model(m->get_model(), device);
         return CompiledModelWrap::Wrap(info.Env(), compiled_model);
     } else {
-        reportError(info.Env(), "Passed Napi::Object is not a Model.");
+        reportError(info.Env(), "Cannot create Model from Napi::Object.");
         return info.Env().Undefined();
     }
 }

--- a/src/bindings/js/node/src/core_wrap.cpp
+++ b/src/bindings/js/node/src/core_wrap.cpp
@@ -76,7 +76,7 @@ Napi::Value CoreWrap::compile_model_sync(const Napi::CallbackInfo& info,
                                          const Napi::Object& model,
                                          const Napi::String& device) {
     if (model.InstanceOf(info.Env().GetInstanceData<AddonData>()->model_prototype->Value().As<Napi::Function>())) {
-        auto m = Napi::ObjectWrap<ModelWrap>::Unwrap(model);
+        const auto m = Napi::ObjectWrap<ModelWrap>::Unwrap(model);
         const auto& compiled_model = _core.compile_model(m->get_model(), device);
         return CompiledModelWrap::Wrap(info.Env(), compiled_model);
     } else {

--- a/src/bindings/js/node/src/infer_request.cpp
+++ b/src/bindings/js/node/src/infer_request.cpp
@@ -36,9 +36,6 @@ Napi::Function InferRequestWrap::GetClassConstructor(Napi::Env env) {
 Napi::Object InferRequestWrap::Init(Napi::Env env, Napi::Object exports) {
     auto func = GetClassConstructor(env);
 
-    Napi::FunctionReference* constructor = new Napi::FunctionReference();
-    *constructor = Napi::Persistent(func);
-    env.SetInstanceData(constructor);
 
     exports.Set("InferRequest", func);
     return exports;

--- a/src/bindings/js/node/src/model_wrap.cpp
+++ b/src/bindings/js/node/src/model_wrap.cpp
@@ -3,6 +3,7 @@
 
 #include "model_wrap.hpp"
 
+#include "addon.hpp"
 #include "node_output.hpp"
 
 ModelWrap::ModelWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<ModelWrap>(info) {}
@@ -18,13 +19,14 @@ Napi::Function ModelWrap::GetClassConstructor(Napi::Env env) {
 }
 
 Napi::Object ModelWrap::Init(Napi::Env env, Napi::Object exports) {
-    Napi::Function func = GetClassConstructor(env);
+    Napi::Function prototype = GetClassConstructor(env);
 
     Napi::FunctionReference* constructor = new Napi::FunctionReference();
-    *constructor = Napi::Persistent(func);
-    env.SetInstanceData(constructor);
+    *constructor = Napi::Persistent(prototype);
+    auto data = env.GetInstanceData<AddonData>();
+    data->model_prototype = constructor;
 
-    exports.Set("Model", func);
+    exports.Set("Model", prototype);
     return exports;
 }
 
@@ -34,7 +36,7 @@ void ModelWrap::set_model(const std::shared_ptr<ov::Model>& model) {
 
 Napi::Object ModelWrap::Wrap(Napi::Env env, std::shared_ptr<ov::Model> model) {
     Napi::HandleScope scope(env);
-    Napi::Object obj = ModelWrap::GetClassConstructor(env).New({});
+    auto obj = env.GetInstanceData<AddonData>()->model_prototype->New({});
     ModelWrap* m = Napi::ObjectWrap<ModelWrap>::Unwrap(obj);
     m->set_model(model);
     return obj;

--- a/src/bindings/js/node/src/model_wrap.cpp
+++ b/src/bindings/js/node/src/model_wrap.cpp
@@ -36,10 +36,14 @@ void ModelWrap::set_model(const std::shared_ptr<ov::Model>& model) {
 
 Napi::Object ModelWrap::Wrap(Napi::Env env, std::shared_ptr<ov::Model> model) {
     Napi::HandleScope scope(env);
-    auto obj = env.GetInstanceData<AddonData>()->model_prototype->New({});
-    ModelWrap* m = Napi::ObjectWrap<ModelWrap>::Unwrap(obj);
-    m->set_model(model);
-    return obj;
+    const auto prototype = env.GetInstanceData<AddonData>()->model_prototype;
+    if (!prototype) {
+        OPENVINO_THROW("Invalid pointer to model prototype.");
+    }
+    const auto& model_js = prototype->New({});
+    ModelWrap* mw = Napi::ObjectWrap<ModelWrap>::Unwrap(model_js);
+    mw->set_model(model);
+    return model_js;
 }
 
 Napi::Value ModelWrap::get_name(const Napi::CallbackInfo& info) {

--- a/src/bindings/js/node/src/model_wrap.cpp
+++ b/src/bindings/js/node/src/model_wrap.cpp
@@ -19,12 +19,12 @@ Napi::Function ModelWrap::GetClassConstructor(Napi::Env env) {
 }
 
 Napi::Object ModelWrap::Init(Napi::Env env, Napi::Object exports) {
-    Napi::Function prototype = GetClassConstructor(env);
+    const auto& prototype = GetClassConstructor(env);
 
-    Napi::FunctionReference* constructor = new Napi::FunctionReference();
-    *constructor = Napi::Persistent(prototype);
-    auto data = env.GetInstanceData<AddonData>();
-    data->model_prototype = constructor;
+    const auto prototype_ref = new Napi::FunctionReference();
+    *prototype_ref = Napi::Persistent(prototype);
+    const auto data = env.GetInstanceData<AddonData>(); 
+    data->model_prototype = prototype_ref;
 
     exports.Set("Model", prototype);
     return exports;

--- a/src/bindings/js/node/src/model_wrap.cpp
+++ b/src/bindings/js/node/src/model_wrap.cpp
@@ -21,10 +21,10 @@ Napi::Function ModelWrap::GetClassConstructor(Napi::Env env) {
 Napi::Object ModelWrap::Init(Napi::Env env, Napi::Object exports) {
     const auto& prototype = GetClassConstructor(env);
 
-    const auto prototype_ref = new Napi::FunctionReference();
-    *prototype_ref = Napi::Persistent(prototype);
+    const auto ref = new Napi::FunctionReference();
+    *ref = Napi::Persistent(prototype);
     const auto data = env.GetInstanceData<AddonData>(); 
-    data->model_prototype = prototype_ref;
+    data->model_prototype = ref;
 
     exports.Set("Model", prototype);
     return exports;

--- a/src/bindings/js/node/src/node_output.cpp
+++ b/src/bindings/js/node/src/node_output.cpp
@@ -69,10 +69,6 @@ Napi::Function Output<const ov::Node>::GetClassConstructor(Napi::Env env) {
 Napi::Object Output<const ov::Node>::Init(Napi::Env env, Napi::Object exports) {
     auto func = GetClassConstructor(env);
 
-    // Napi::FunctionReference* constructor = new Napi::FunctionReference();
-    // *constructor = Napi::Persistent(func);
-    // env.SetInstanceData(constructor);
-
     exports.Set("Output", func);
     return exports;
 }

--- a/src/bindings/js/node/src/node_output.cpp
+++ b/src/bindings/js/node/src/node_output.cpp
@@ -23,9 +23,6 @@ Napi::Function Output<ov::Node>::GetClassConstructor(Napi::Env env) {
 Napi::Object Output<ov::Node>::Init(Napi::Env env, Napi::Object exports) {
     auto func = GetClassConstructor(env);
 
-    Napi::FunctionReference* constructor = new Napi::FunctionReference();
-    *constructor = Napi::Persistent(func);
-    env.SetInstanceData(constructor);
 
     exports.Set("Output", func);
     return exports;
@@ -72,9 +69,9 @@ Napi::Function Output<const ov::Node>::GetClassConstructor(Napi::Env env) {
 Napi::Object Output<const ov::Node>::Init(Napi::Env env, Napi::Object exports) {
     auto func = GetClassConstructor(env);
 
-    Napi::FunctionReference* constructor = new Napi::FunctionReference();
-    *constructor = Napi::Persistent(func);
-    env.SetInstanceData(constructor);
+    // Napi::FunctionReference* constructor = new Napi::FunctionReference();
+    // *constructor = Napi::Persistent(func);
+    // env.SetInstanceData(constructor);
 
     exports.Set("Output", func);
     return exports;

--- a/src/bindings/js/node/src/partial_shape_wrap.cpp
+++ b/src/bindings/js/node/src/partial_shape_wrap.cpp
@@ -41,9 +41,6 @@ Napi::Function PartialShapeWrap::GetClassConstructor(Napi::Env env) {
 Napi::Object PartialShapeWrap::Init(Napi::Env env, Napi::Object exports) {
     auto func = GetClassConstructor(env);
 
-    Napi::FunctionReference* constructor = new Napi::FunctionReference();
-    *constructor = Napi::Persistent(func);
-    env.SetInstanceData(constructor);
 
     exports.Set("PartialShape", func);
     return exports;

--- a/src/bindings/js/node/src/preprocess/pre_post_process_wrap.cpp
+++ b/src/bindings/js/node/src/preprocess/pre_post_process_wrap.cpp
@@ -27,9 +27,6 @@ Napi::Function PrePostProcessorWrap::GetClassConstructor(Napi::Env env) {
 Napi::Object PrePostProcessorWrap::Init(Napi::Env env, Napi::Object exports) {
     auto func = GetClassConstructor(env);
 
-    Napi::FunctionReference* constructor = new Napi::FunctionReference();
-    *constructor = Napi::Persistent(func);
-    env.SetInstanceData(constructor);
 
     exports.Set("PrePostProcessor", func);
     return exports;

--- a/src/bindings/js/node/src/tensor.cpp
+++ b/src/bindings/js/node/src/tensor.cpp
@@ -50,9 +50,6 @@ Napi::Function TensorWrap::GetClassConstructor(Napi::Env env) {
 Napi::Object TensorWrap::Init(Napi::Env env, Napi::Object exports) {
     auto func = GetClassConstructor(env);
 
-    Napi::FunctionReference* constructor = new Napi::FunctionReference();
-    *constructor = Napi::Persistent(func);
-    env.SetInstanceData(constructor);
 
     exports.Set("Tensor", func);
     return exports;


### PR DESCRIPTION
### Details:
 - Napi::Env.SetInstanceData() should be set once and store all the data that we want to associate with js api addon instance.
 - Includes examples how to create js objects on C++ side and check its type. 

### Tickets:
 - *20313*
